### PR TITLE
Add "svelte" entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Svelte component for rendering outside the DOM of parent component",
   "main": "src/main.cjs.js",
   "module": "src/main.es.js",
+  "svelte": "src/Portal.svelte",
   "scripts": {
     "test": "jest test",
     "test:watch": "npm run test -- --watch",


### PR DESCRIPTION
Adding the "svelte" property to package.json is recommended by:

- https://github.com/sveltejs/component-template#consuming-components
- https://github.com/sveltejs/rollup-plugin-svelte#pkgsvelte

Without it, when using SvelteKit, and doing the following import:

```javascript
import { portal } from "svelte-portal"
```

I get this error:

```
/home/cbenz/Dev/tests/my-project/node_modules/svelte-portal/src/Portal.svelte:1
<script context="module">
^

SyntaxError: Unexpected token '<'
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/home/cbenz/Dev/tests/my-project/node_modules/svelte-portal/src/main.cjs.js:1:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
```

Adding the "svelte" property to package.json solves the error.
