### PR TITLE
use ownerDocument or node, use restProps on parent node, set mode to immutable

### DIFF
--- a/src/Portal.svelte
+++ b/src/Portal.svelte
@@ -1,6 +1,7 @@
+<svelte:options immutable />
+
 <script context="module">
   import { tick } from "svelte";
-
   /**
    * Usage: <div use:portal={'css selector'}> or <div use:portal={document.body}>
    *
@@ -8,6 +9,7 @@
    * @param {HTMLElement|string} target DOM Element or CSS Selector
    */
   export function portal(el, target = "body") {
+    const document = el.ownerDocument;
     let targetEl;
     async function update(newTarget) {
       target = newTarget;
@@ -57,6 +59,6 @@
   export let target = "body";
 </script>
 
-<div use:portal={target} hidden>
+<div {...$$restProps} use:portal={target} hidden>
   <slot />
 </div>

--- a/test/Portal.test.js
+++ b/test/Portal.test.js
@@ -36,6 +36,18 @@ describe("<Portal /> target", () => {
     expect(renderedDivInTargetClass).not.toBe(null);
   });
 
+  it("should be rendererd in the default HTML element (document.body) with attributes on parent", () => {
+    const renderedInDefaultWithProps = wrapper.querySelector(
+      "body #renderedInDefaultWithAttributes"
+    );
+
+    expect(renderedInDefaultWithProps).not.toBe(null);
+    expect(renderedInDefaultWithProps.parentNode).not.toBe(null);
+    expect(renderedInDefaultWithProps.parentNode.style.position).toBe(
+      "absolute"
+    );
+  });
+
   it("should not render a Portal at the origin", () => {
     const portalContainer = wrapper.querySelector("#portalCtn");
     const isPortalContainerEmpty =

--- a/test/TestPortalWrapper.svelte
+++ b/test/TestPortalWrapper.svelte
@@ -14,6 +14,11 @@
       <Portal target="body > .target">
         <div id="renderedInTargetClass"></div>
       </Portal>
+      <Portal
+        style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);"
+      >
+        <div id="renderedInDefaultWithAttributes"></div>
+      </Portal>
     </div>
   </main>
 


### PR DESCRIPTION
- use el.ownerDocument of mounted element to insure local document tree
- pass $$restProps to parent div to allow adding attributes to root portal element
- use immutable mode since target props does not require mutations to be allow