### PR TITLE
Add a default field in exports to fix build on webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./src/Portal.svelte.d.ts",
-      "svelte": "./src/main.es.js"
+      "svelte": "./src/main.es.js",
+      "default": "./src/main.es.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Not having a default in exports causes this error

Module not found
Package path . is not exported from package